### PR TITLE
Fix incorrect repository URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This app is meant to be used as a starting point to build a conversational assis
 2. **Clone the Repository:**
 
    ```bash
-   git clone https://github.com/openai/responses-starter-app.git
+   git clone https://github.com/openai/openai-responses-starter-app.git
    ```
 
 3. **Install dependencies:**


### PR DESCRIPTION
This PR fixes the incorrect repository URL in the README.

## Description
The current README contains an incorrect repository URL (`https://github.com/openai/responses-starter-app.git`), which results in a "Repository not found" error when attempting to clone.

## Changes
- Updated the URL to the correct repository: `https://github.com/openai/openai-responses-starter-app.git`

## Testing
Verified that the new URL works correctly by successfully cloning the repository.