### PR TITLE
fix: removal of 'Connection: keep-alive'

### DIFF
--- a/app/api/turn_response/route.ts
+++ b/app/api/turn_response/route.ts
@@ -43,7 +43,6 @@ export async function POST(request: Request) {
       headers: {
         "Content-Type": "text/event-stream",
         "Cache-Control": "no-cache",
-        Connection: "keep-alive",
       },
     });
   } catch (error) {


### PR DESCRIPTION
### Description

Removed 'Connection: keep-alive' from the turn_response Response.

### Motivation

Connection is a forbidden header and may cause issues with Safari on HTTP/2 - [https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Connection](url)