### PR TITLE
Add code interpreter tool

### DIFF
--- a/app/api/container_files/content/route.ts
+++ b/app/api/container_files/content/route.ts
@@ -1,0 +1,29 @@
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const fileId = searchParams.get("file_id");
+  if (!fileId) {
+    return new Response(JSON.stringify({ error: "Missing file_id" }), {
+      status: 400,
+    });
+  }
+  try {
+    const res = await fetch(`https://api.openai.com/v1/container-files/${fileId}/content`, {
+      headers: {
+        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+      },
+    });
+    if (!res.ok) throw new Error(`Failed to fetch file: ${res.status}`);
+    const blob = await res.blob();
+    return new Response(blob, {
+      headers: {
+        "Content-Type": res.headers.get("Content-Type") || "application/octet-stream",
+        "Content-Disposition": `attachment; filename=${fileId}`,
+      },
+    });
+  } catch (err) {
+    console.error("Error fetching container file", err);
+    return new Response(JSON.stringify({ error: "Failed to fetch file" }), {
+      status: 500,
+    });
+  }
+}

--- a/components/annotations.tsx
+++ b/components/annotations.tsx
@@ -1,7 +1,7 @@
 import { ExternalLinkIcon } from "lucide-react";
 
 export type Annotation = {
-  type: "file_citation" | "url_citation";
+  type: "file_citation" | "url_citation" | "file_path";
   fileId?: string;
   url?: string;
   title?: string;
@@ -30,6 +30,17 @@ const AnnotationPill = ({ annotation }: { annotation: Annotation }) => {
           </div>
         </a>
       );
+    case "file_path":
+      return (
+        <a
+          href={`/api/container_files/content?file_id=${annotation.fileId}`}
+          download
+          className={`${className} flex items-center gap-1`}
+        >
+          <span className="truncate">{annotation.fileId}</span>
+          <ExternalLinkIcon size={12} className="shrink-0" />
+        </a>
+      );
   }
 };
 
@@ -42,7 +53,8 @@ const Annotations = ({ annotations }: { annotations: Annotation[] }) => {
             a.type === annotation.type &&
             ((annotation.type === "file_citation" &&
               a.fileId === annotation.fileId) ||
-              (annotation.type === "url_citation" && a.url === annotation.url))
+              (annotation.type === "url_citation" && a.url === annotation.url) ||
+              (annotation.type === "file_path" && a.fileId === annotation.fileId))
         )
       ) {
         acc.push(annotation);

--- a/components/tool-call.tsx
+++ b/components/tool-call.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 import { ToolCallItem } from "@/lib/assistant";
-import { BookOpenText, Clock, Globe, Zap } from "lucide-react";
+import { BookOpenText, Clock, Globe, Zap, Code2, Download, ChevronDown } from "lucide-react";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { coy } from "react-syntax-highlighter/dist/esm/styles/prism";
 
@@ -94,6 +94,56 @@ function WebSearchCell({ toolCall }: ToolCallProps) {
   );
 }
 
+function CodeInterpreterCell({ toolCall }: ToolCallProps) {
+  const [open, setOpen] = React.useState(false);
+  return (
+    <div className="flex flex-col w-[70%] relative mb-[-8px]">
+      <div className="flex flex-col text-sm rounded-[16px]">
+        <div className="font-semibold p-3 pl-0 text-gray-700 rounded-b-none flex gap-2">
+          <div className="flex gap-2 items-center text-blue-500 ml-[-8px] cursor-pointer" onClick={() => setOpen(!open)}>
+            <Code2 size={16} />
+            <div className="text-sm font-medium">Code executed</div>
+            <ChevronDown size={16} className={open ? "rotate-180 transition-transform" : "transition-transform"} />
+          </div>
+        </div>
+        {open && (
+          <div className="bg-[#fafafa] rounded-xl py-2 ml-4 mt-2">
+            <div className="mx-6 p-2 text-xs">
+              <SyntaxHighlighter
+                customStyle={{ backgroundColor: "#fafafa", padding: "8px", paddingLeft: "0px", marginTop: 0 }}
+                language="python"
+                style={coy}
+              >
+                {toolCall.code || ""}
+              </SyntaxHighlighter>
+            </div>
+          </div>
+        )}
+        {toolCall.output && (
+          <div className="bg-[#fafafa] rounded-xl py-2 ml-4 mt-2 mx-6 p-2 text-xs whitespace-pre-wrap">
+            {toolCall.output}
+          </div>
+        )}
+        {toolCall.files && toolCall.files.length > 0 && (
+          <div className="flex gap-2 mt-2 ml-4 flex-wrap">
+            {toolCall.files.map((f) => (
+              <a
+                key={f.file_id}
+                href={`/api/container_files/content?file_id=${f.file_id}`}
+                download
+                className="inline-flex items-center gap-1 px-3 py-1 rounded-full bg-[#ededed] text-xs text-zinc-500"
+              >
+                {f.file_id}
+                <Download size={12} />
+              </a>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
 export default function ToolCall({ toolCall }: ToolCallProps) {
   return (
     <div className="flex justify-start pt-2">
@@ -105,6 +155,8 @@ export default function ToolCall({ toolCall }: ToolCallProps) {
             return <FileSearchCell toolCall={toolCall} />;
           case "web_search_call":
             return <WebSearchCell toolCall={toolCall} />;
+          case "code_interpreter_call":
+            return <CodeInterpreterCell toolCall={toolCall} />;
           default:
             return null;
         }

--- a/components/tools-panel.tsx
+++ b/components/tools-panel.tsx
@@ -14,6 +14,8 @@ export default function ContextPanel() {
     setWebSearchEnabled,
     functionsEnabled,
     setFunctionsEnabled,
+    codeInterpreterEnabled,
+    setCodeInterpreterEnabled,
   } = useToolsStore();
   return (
     <div className="h-full p-8 w-full bg-[#f9f9f9] rounded-t-xl md:rounded-none border-l-1 border-stone-100">
@@ -42,6 +44,12 @@ export default function ContextPanel() {
         >
           <FunctionsView />
         </PanelConfig>
+        <PanelConfig
+          title="Code Interpreter"
+          tooltip="Allows the assistant to run Python code"
+          enabled={codeInterpreterEnabled}
+          setEnabled={setCodeInterpreterEnabled}
+        />
       </div>
     </div>
   );

--- a/config/constants.ts
+++ b/config/constants.ts
@@ -1,4 +1,4 @@
-export const MODEL = "gpt-4o-mini";
+export const MODEL = "gpt-4.1";
 
 // Developer prompt for the assistant
 export const DEVELOPER_PROMPT = `

--- a/lib/assistant.ts
+++ b/lib/assistant.ts
@@ -23,7 +23,11 @@ export interface MessageItem {
 // Custom items to display in chat
 export interface ToolCallItem {
   type: "tool_call";
-  tool_type: "file_search_call" | "web_search_call" | "function_call";
+  tool_type:
+    | "file_search_call"
+    | "web_search_call"
+    | "function_call"
+    | "code_interpreter_call";
   status: "in_progress" | "completed" | "failed" | "searching";
   id: string;
   name?: string | null;
@@ -31,6 +35,8 @@ export interface ToolCallItem {
   arguments?: string;
   parsedArguments?: any;
   output?: string | null;
+  code?: string;
+  files?: { file_id: string; mime_type: string }[];
 }
 
 export type Item = MessageItem | ToolCallItem;
@@ -234,6 +240,18 @@ export const processMessages = async () => {
             setChatMessages([...chatMessages]);
             break;
           }
+          case "code_interpreter_call": {
+            chatMessages.push({
+              type: "tool_call",
+              tool_type: "code_interpreter_call",
+              status: item.status || "in_progress",
+              id: item.id,
+              code: "",
+              files: [],
+            });
+            setChatMessages([...chatMessages]);
+            break;
+          }
         }
         break;
       }
@@ -329,6 +347,46 @@ export const processMessages = async () => {
         const toolCallMessage = chatMessages.find((m) => m.id === item_id);
         if (toolCallMessage && toolCallMessage.type === "tool_call") {
           toolCallMessage.output = output;
+          toolCallMessage.status = "completed";
+          setChatMessages([...chatMessages]);
+        }
+        break;
+      }
+
+      case "response.code_interpreter_call.code.delta": {
+        const { delta } = data;
+        const toolCallMessage = [...chatMessages]
+          .reverse()
+          .find((m) => m.type === "tool_call" && m.tool_type === "code_interpreter_call" && m.status !== "completed") as ToolCallItem | undefined;
+        if (toolCallMessage) {
+          toolCallMessage.code = (toolCallMessage.code || "") + delta;
+          setChatMessages([...chatMessages]);
+        }
+        break;
+      }
+
+      case "response.code_interpreter_call.code.done": {
+        const { code } = data;
+        const toolCallMessage = [...chatMessages]
+          .reverse()
+          .find((m) => m.type === "tool_call" && m.tool_type === "code_interpreter_call" && m.status !== "completed") as ToolCallItem | undefined;
+        if (toolCallMessage) {
+          toolCallMessage.code = code;
+          setChatMessages([...chatMessages]);
+        }
+        break;
+      }
+
+      case "response.code_interpreter_call.completed": {
+        const { code_interpreter_call } = data;
+        const toolCallMessage = chatMessages.find((m) => m.id === code_interpreter_call.id);
+        if (toolCallMessage && toolCallMessage.type === "tool_call") {
+          const files = code_interpreter_call.results
+            .filter((r: any) => r.type === "files")
+            .flatMap((r: any) => r.files);
+          toolCallMessage.files = files;
+          const logsObj = code_interpreter_call.results.find((r: any) => r.type === "logs");
+          if (logsObj) toolCallMessage.output = (logsObj as any).logs;
           toolCallMessage.status = "completed";
           setChatMessages([...chatMessages]);
         }

--- a/lib/tools/tools.ts
+++ b/lib/tools/tools.ts
@@ -10,6 +10,7 @@ export const getTools = () => {
     webSearchEnabled,
     fileSearchEnabled,
     functionsEnabled,
+    codeInterpreterEnabled,
     vectorStore,
     webSearchConfig,
   } = useToolsStore.getState();
@@ -38,6 +39,10 @@ export const getTools = () => {
       vector_store_ids: [vectorStore?.id],
     };
     tools.push(fileSearchTool);
+  }
+
+  if (codeInterpreterEnabled) {
+    tools.push({ type: "code_interpreter", container: { type: "auto" } });
   }
 
   if (functionsEnabled) {

--- a/stores/useToolsStore.ts
+++ b/stores/useToolsStore.ts
@@ -32,6 +32,8 @@ interface StoreState {
   functionsEnabled: boolean;
   //previousFunctionsEnabled: boolean;
   setFunctionsEnabled: (enabled: boolean) => void;
+  codeInterpreterEnabled: boolean;
+  setCodeInterpreterEnabled: (enabled: boolean) => void;
   vectorStore: VectorStore | null;
   setVectorStore: (store: VectorStore) => void;
   webSearchConfig: WebSearchConfig;
@@ -63,6 +65,10 @@ const useToolsStore = create<StoreState>()(
       previousFunctionsEnabled: true,
       setFunctionsEnabled: (enabled) => {
         set({ functionsEnabled: enabled });
+      },
+      codeInterpreterEnabled: false,
+      setCodeInterpreterEnabled: (enabled) => {
+        set({ codeInterpreterEnabled: enabled });
       },
       setVectorStore: (store) => set({ vectorStore: store }),
       setWebSearchConfig: (config) => set({ webSearchConfig: config }),


### PR DESCRIPTION
## Summary
- set default model to `gpt-4.1`
- allow enabling the code interpreter tool in the Tools panel
- persist code interpreter state
- send `code_interpreter` config when enabled
- stream and display code execution results
- allow downloading generated container files
- fix container file download route

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_i_6843fc95ecd0832ab6b99f60f5871f27