### PR TITLE
Add MCP tool support

### DIFF
--- a/components/mcp-config.tsx
+++ b/components/mcp-config.tsx
@@ -1,0 +1,91 @@
+"use client";
+import React from "react";
+import useToolsStore from "@/stores/useToolsStore";
+import { Input } from "./ui/input";
+import { Switch } from "./ui/switch";
+
+export default function McpConfig() {
+  const { mcpConfig, setMcpConfig } = useToolsStore();
+
+  const handleClear = () => {
+    setMcpConfig({
+      server_label: "",
+      server_url: "",
+      allowed_tools: "",
+      skip_approval: false,
+    });
+  };
+
+  return (
+    <div>
+      <div className="flex items-center justify-between">
+        <div className="text-zinc-600 text-sm">Server details</div>
+        <div
+          className="text-zinc-400 text-sm px-1 transition-colors hover:text-zinc-600 cursor-pointer"
+          onClick={handleClear}
+        >
+          Clear
+        </div>
+      </div>
+      <div className="mt-3 space-y-3 text-zinc-400">
+        <div className="flex items-center gap-2">
+          <label htmlFor="server_label" className="text-sm w-24">
+            Label
+          </label>
+          <Input
+            id="server_label"
+            type="text"
+            placeholder="deepwiki"
+            className="bg-white border text-sm flex-1 text-zinc-900 placeholder:text-zinc-400"
+            value={mcpConfig.server_label}
+            onChange={(e) =>
+              setMcpConfig({ ...mcpConfig, server_label: e.target.value })
+            }
+          />
+        </div>
+        <div className="flex items-center gap-2">
+          <label htmlFor="server_url" className="text-sm w-24">
+            URL
+          </label>
+          <Input
+            id="server_url"
+            type="text"
+            placeholder="https://example.com/mcp"
+            className="bg-white border text-sm flex-1 text-zinc-900 placeholder:text-zinc-400"
+            value={mcpConfig.server_url}
+            onChange={(e) =>
+              setMcpConfig({ ...mcpConfig, server_url: e.target.value })
+            }
+          />
+        </div>
+        <div className="flex items-center gap-2">
+          <label htmlFor="allowed_tools" className="text-sm w-24">
+            Allowed
+          </label>
+          <Input
+            id="allowed_tools"
+            type="text"
+            placeholder="tool1,tool2"
+            className="bg-white border text-sm flex-1 text-zinc-900 placeholder:text-zinc-400"
+            value={mcpConfig.allowed_tools}
+            onChange={(e) =>
+              setMcpConfig({ ...mcpConfig, allowed_tools: e.target.value })
+            }
+          />
+        </div>
+        <div className="flex items-center gap-2">
+          <label htmlFor="skip_approval" className="text-sm w-24">
+            Skip approval
+          </label>
+          <Switch
+            id="skip_approval"
+            checked={mcpConfig.skip_approval}
+            onCheckedChange={(checked) =>
+              setMcpConfig({ ...mcpConfig, skip_approval: checked })
+            }
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/tool-call.tsx
+++ b/components/tool-call.tsx
@@ -94,6 +94,65 @@ function WebSearchCell({ toolCall }: ToolCallProps) {
   );
 }
 
+function McpCallCell({ toolCall }: ToolCallProps) {
+  return (
+    <div className="flex flex-col w-[70%] relative mb-[-8px]">
+      <div>
+        <div className="flex flex-col text-sm rounded-[16px]">
+          <div className="font-semibold p-3 pl-0 text-gray-700 rounded-b-none flex gap-2">
+            <div className="flex gap-2 items-center text-blue-500 ml-[-8px]">
+              <Zap size={16} />
+              <div className="text-sm font-medium">
+                {toolCall.status === "completed"
+                  ? `Called ${toolCall.name} via MCP tool`
+                  : `Calling ${toolCall.name} via MCP tool...`}
+              </div>
+            </div>
+          </div>
+
+          <div className="bg-[#fafafa] rounded-xl py-2 ml-4 mt-2">
+            <div className="max-h-96 overflow-y-scroll text-xs border-b mx-6 p-2">
+              <SyntaxHighlighter
+                customStyle={{
+                  backgroundColor: "#fafafa",
+                  padding: "8px",
+                  paddingLeft: "0px",
+                  marginTop: 0,
+                  marginBottom: 0,
+                }}
+                language="json"
+                style={coy}
+              >
+                {JSON.stringify(toolCall.parsedArguments, null, 2)}
+              </SyntaxHighlighter>
+            </div>
+            <div className="max-h-96 overflow-y-scroll mx-6 p-2 text-xs">
+              {toolCall.output ? (
+                <SyntaxHighlighter
+                  customStyle={{
+                    backgroundColor: "#fafafa",
+                    padding: "8px",
+                    paddingLeft: "0px",
+                    marginTop: 0,
+                  }}
+                  language="json"
+                  style={coy}
+                >
+                  {JSON.stringify(JSON.parse(toolCall.output), null, 2)}
+                </SyntaxHighlighter>
+              ) : (
+                <div className="text-zinc-500 flex items-center gap-2 py-2">
+                  <Clock size={16} /> Waiting for result...
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export default function ToolCall({ toolCall }: ToolCallProps) {
   return (
     <div className="flex justify-start pt-2">
@@ -105,6 +164,8 @@ export default function ToolCall({ toolCall }: ToolCallProps) {
             return <FileSearchCell toolCall={toolCall} />;
           case "web_search_call":
             return <WebSearchCell toolCall={toolCall} />;
+          case "mcp_call":
+            return <McpCallCell toolCall={toolCall} />;
           default:
             return null;
         }

--- a/components/tools-panel.tsx
+++ b/components/tools-panel.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import FileSearchSetup from "./file-search-setup";
 import WebSearchConfig from "./websearch-config";
 import FunctionsView from "./functions-view";
+import McpConfig from "./mcp-config";
 import PanelConfig from "./panel-config";
 import useToolsStore from "@/stores/useToolsStore";
 
@@ -14,6 +15,8 @@ export default function ContextPanel() {
     setWebSearchEnabled,
     functionsEnabled,
     setFunctionsEnabled,
+    mcpEnabled,
+    setMcpEnabled,
   } = useToolsStore();
   return (
     <div className="h-full p-8 w-full bg-[#f9f9f9] rounded-t-xl md:rounded-none border-l-1 border-stone-100">
@@ -41,6 +44,14 @@ export default function ContextPanel() {
           setEnabled={setFunctionsEnabled}
         >
           <FunctionsView />
+        </PanelConfig>
+        <PanelConfig
+          title="MCP"
+          tooltip="Allows to call tools via remote MCP server"
+          enabled={mcpEnabled}
+          setEnabled={setMcpEnabled}
+        >
+          <McpConfig />
         </PanelConfig>
       </div>
     </div>

--- a/lib/assistant.ts
+++ b/lib/assistant.ts
@@ -23,7 +23,11 @@ export interface MessageItem {
 // Custom items to display in chat
 export interface ToolCallItem {
   type: "tool_call";
-  tool_type: "file_search_call" | "web_search_call" | "function_call";
+  tool_type:
+    | "file_search_call"
+    | "web_search_call"
+    | "function_call"
+    | "mcp_call";
   status: "in_progress" | "completed" | "failed" | "searching";
   id: string;
   name?: string | null;
@@ -234,6 +238,20 @@ export const processMessages = async () => {
             setChatMessages([...chatMessages]);
             break;
           }
+          case "mcp_call": {
+            chatMessages.push({
+              type: "tool_call",
+              tool_type: "mcp_call",
+              status: "in_progress",
+              id: item.id,
+              name: item.name,
+              arguments: item.arguments || "",
+              parsedArguments: item.arguments ? parse(item.arguments) : {},
+              output: null,
+            });
+            setChatMessages([...chatMessages]);
+            break;
+          }
         }
         break;
       }
@@ -272,6 +290,15 @@ export const processMessages = async () => {
 
           // Create another turn after tool output has been added
           await processMessages();
+        }
+        if (
+          toolCallMessage &&
+          toolCallMessage.type === "tool_call" &&
+          toolCallMessage.tool_type === "mcp_call"
+        ) {
+          toolCallMessage.output = item.output;
+          toolCallMessage.status = "completed";
+          setChatMessages([...chatMessages]);
         }
       }
 
@@ -334,6 +361,8 @@ export const processMessages = async () => {
         }
         break;
       }
+
+
 
       // Handle other events as needed
     }

--- a/lib/tools/tools.ts
+++ b/lib/tools/tools.ts
@@ -12,6 +12,8 @@ export const getTools = () => {
     functionsEnabled,
     vectorStore,
     webSearchConfig,
+    mcpEnabled,
+    mcpConfig,
   } = useToolsStore.getState();
 
   const tools = [];
@@ -57,6 +59,24 @@ export const getTools = () => {
         };
       })
     );
+  }
+
+  if (mcpEnabled && mcpConfig.server_url && mcpConfig.server_label) {
+    const mcpTool: any = {
+      type: "mcp",
+      server_label: mcpConfig.server_label,
+      server_url: mcpConfig.server_url,
+    };
+    if (mcpConfig.skip_approval) {
+      mcpTool.require_approval = "never";
+    }
+    if (mcpConfig.allowed_tools.trim()) {
+      mcpTool.allowed_tools = mcpConfig.allowed_tools
+        .split(",")
+        .map((t) => t.trim())
+        .filter((t) => t);
+    }
+    tools.push(mcpTool);
   }
 
   console.log("tools", tools);

--- a/stores/useToolsStore.ts
+++ b/stores/useToolsStore.ts
@@ -23,6 +23,13 @@ export type WebSearchConfig = {
   };
 };
 
+export type McpConfig = {
+  server_label: string;
+  server_url: string;
+  allowed_tools: string;
+  skip_approval: boolean;
+};
+
 interface StoreState {
   fileSearchEnabled: boolean;
   //previousFileSearchEnabled: boolean;
@@ -36,6 +43,10 @@ interface StoreState {
   setVectorStore: (store: VectorStore) => void;
   webSearchConfig: WebSearchConfig;
   setWebSearchConfig: (config: WebSearchConfig) => void;
+  mcpEnabled: boolean;
+  setMcpEnabled: (enabled: boolean) => void;
+  mcpConfig: McpConfig;
+  setMcpConfig: (config: McpConfig) => void;
 }
 
 const useToolsStore = create<StoreState>()(
@@ -49,6 +60,12 @@ const useToolsStore = create<StoreState>()(
           city: "",
           region: "",
         },
+      },
+      mcpConfig: {
+        server_label: "",
+        server_url: "",
+        allowed_tools: "",
+        skip_approval: false,
       },
       fileSearchEnabled: false,
       previousFileSearchEnabled: false,
@@ -64,8 +81,13 @@ const useToolsStore = create<StoreState>()(
       setFunctionsEnabled: (enabled) => {
         set({ functionsEnabled: enabled });
       },
+      mcpEnabled: false,
+      setMcpEnabled: (enabled) => {
+        set({ mcpEnabled: enabled });
+      },
       setVectorStore: (store) => set({ vectorStore: store }),
       setWebSearchConfig: (config) => set({ webSearchConfig: config }),
+      setMcpConfig: (config) => set({ mcpConfig: config }),
     }),
     {
       name: "tools-store",


### PR DESCRIPTION
## Summary
- add MCP tool config form
- wire up MCP settings in store and tool builder
- render MCP calls and show output in chat
- update assistant logic to track MCP tool calls

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_i_6843fd4e1524832ab5532c069d8da1c6