### PR TITLE
Fix container file downloads and inline image display

### DIFF
--- a/app/api/container_files/content/route.ts
+++ b/app/api/container_files/content/route.ts
@@ -1,13 +1,17 @@
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const fileId = searchParams.get("file_id");
+  const containerId = searchParams.get("container_id");
   if (!fileId) {
     return new Response(JSON.stringify({ error: "Missing file_id" }), {
       status: 400,
     });
   }
   try {
-    const res = await fetch(`https://api.openai.com/v1/container-files/${fileId}/content`, {
+    const url = containerId
+      ? `https://api.openai.com/v1/containers/${containerId}/files/${fileId}/content`
+      : `https://api.openai.com/v1/container-files/${fileId}/content`;
+    const res = await fetch(url, {
       headers: {
         Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
       },

--- a/components/annotations.tsx
+++ b/components/annotations.tsx
@@ -1,8 +1,12 @@
 import { ExternalLinkIcon } from "lucide-react";
 
 export type Annotation = {
-  type: "file_citation" | "url_citation" | "file_path";
+  type:
+    | "file_citation"
+    | "url_citation"
+    | "container_file_citation";
   fileId?: string;
+  containerId?: string;
   url?: string;
   title?: string;
   filename?: string;
@@ -30,14 +34,14 @@ const AnnotationPill = ({ annotation }: { annotation: Annotation }) => {
           </div>
         </a>
       );
-    case "file_path":
+    case "container_file_citation":
       return (
         <a
-          href={`/api/container_files/content?file_id=${annotation.fileId}`}
+          href={`/api/container_files/content?file_id=${annotation.fileId}${annotation.containerId ? `&container_id=${annotation.containerId}` : ""}`}
           download
           className={`${className} flex items-center gap-1`}
         >
-          <span className="truncate">{annotation.fileId}</span>
+          <span className="truncate">{annotation.filename || annotation.fileId}</span>
           <ExternalLinkIcon size={12} className="shrink-0" />
         </a>
       );
@@ -54,7 +58,7 @@ const Annotations = ({ annotations }: { annotations: Annotation[] }) => {
             ((annotation.type === "file_citation" &&
               a.fileId === annotation.fileId) ||
               (annotation.type === "url_citation" && a.url === annotation.url) ||
-              (annotation.type === "file_path" && a.fileId === annotation.fileId))
+              (annotation.type === "container_file_citation" && a.fileId === annotation.fileId))
         )
       ) {
         acc.push(annotation);

--- a/components/message.tsx
+++ b/components/message.tsx
@@ -31,6 +31,22 @@ const Message: React.FC<MessageProps> = ({ message }) => {
                 <ReactMarkdown>
                   {message.content[0].text as string}
                 </ReactMarkdown>
+                {message.content[0].annotations &&
+                  message.content[0].annotations
+                    .filter(
+                      (a) =>
+                        a.type === "container_file_citation" &&
+                        a.filename &&
+                        /\.(png|jpg|jpeg|gif|webp|svg)$/i.test(a.filename)
+                    )
+                    .map((a, i) => (
+                      <img
+                        key={i}
+                        src={`/api/container_files/content?file_id=${a.fileId}${a.containerId ? `&container_id=${a.containerId}` : ""}`}
+                        alt={a.filename || ""}
+                        className="mt-2 max-w-full"
+                      />
+                    ))}
               </div>
             </div>
           </div>

--- a/components/tool-call.tsx
+++ b/components/tool-call.tsx
@@ -133,11 +133,11 @@ function CodeInterpreterCell({ toolCall }: ToolCallProps) {
             {toolCall.files.map((f) => (
               <a
                 key={f.file_id}
-                href={`/api/container_files/content?file_id=${f.file_id}`}
+                href={`/api/container_files/content?file_id=${f.file_id}${f.container_id ? `&container_id=${f.container_id}` : ""}`}
                 download
                 className="inline-flex items-center gap-1 px-3 py-1 rounded-full bg-[#ededed] text-xs text-zinc-500"
               >
-                {f.file_id}
+                {f.filename || f.file_id}
                 <Download size={12} />
               </a>
             ))}


### PR DESCRIPTION
## Summary
- support new `container_file_citation` annotations
- allow optional container_id when fetching files
- render inline images when file annotations reference images
- capture generated files from code interpreter
- drop old `file_path` annotation handling

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_i_6846ce300198832ab9ed9cab593324cf