### PR TITLE
Handle MCP tool lists and approvals

### DIFF
--- a/components/assistant.tsx
+++ b/components/assistant.tsx
@@ -30,9 +30,30 @@ export default function Assistant() {
     }
   };
 
+  const handleApprovalResponse = async (
+    approve: boolean,
+    id: string
+  ) => {
+    const approvalItem = {
+      type: "mcp_approval_response",
+      approve,
+      approval_request_id: id,
+    } as any;
+    try {
+      addConversationItem(approvalItem);
+      await processMessages();
+    } catch (error) {
+      console.error("Error sending approval response:", error);
+    }
+  };
+
   return (
     <div className="h-full p-4 w-full bg-white">
-      <Chat items={chatMessages} onSendMessage={handleSendMessage} />
+      <Chat
+        items={chatMessages}
+        onSendMessage={handleSendMessage}
+        onApprovalResponse={handleApprovalResponse}
+      />
     </div>
   );
 }

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -4,14 +4,21 @@ import React, { useCallback, useEffect, useRef, useState } from "react";
 import ToolCall from "./tool-call";
 import Message from "./message";
 import Annotations from "./annotations";
-import { Item } from "@/lib/assistant";
+import McpToolsList from "./mcp-tools-list";
+import McpApproval from "./mcp-approval";
+import { Item, McpApprovalRequestItem } from "@/lib/assistant";
 
 interface ChatProps {
   items: Item[];
   onSendMessage: (message: string) => void;
+  onApprovalResponse: (approve: boolean, id: string) => void;
 }
 
-const Chat: React.FC<ChatProps> = ({ items, onSendMessage }) => {
+const Chat: React.FC<ChatProps> = ({
+  items,
+  onSendMessage,
+  onApprovalResponse,
+}) => {
   const itemsEndRef = useRef<HTMLDivElement>(null);
   const [inputMessageText, setinputMessageText] = useState<string>("");
   // This state is used to provide better user experience for non-English IMEs such as Japanese
@@ -53,6 +60,13 @@ const Chat: React.FC<ChatProps> = ({ items, onSendMessage }) => {
                         />
                       )}
                   </div>
+                ) : item.type === "mcp_list_tools" ? (
+                  <McpToolsList item={item} />
+                ) : item.type === "mcp_approval_request" ? (
+                  <McpApproval
+                    item={item as McpApprovalRequestItem}
+                    onRespond={onApprovalResponse}
+                  />
                 ) : null}
               </React.Fragment>
             ))}

--- a/components/mcp-approval.tsx
+++ b/components/mcp-approval.tsx
@@ -1,0 +1,43 @@
+"use client";
+import React, { useState } from "react";
+import { Button } from "./ui/button";
+import { McpApprovalRequestItem } from "@/lib/assistant";
+
+interface Props {
+  item: McpApprovalRequestItem;
+  onRespond: (approve: boolean, id: string) => void;
+}
+
+export default function McpApproval({ item, onRespond }: Props) {
+  const [disabled, setDisabled] = useState(false);
+
+  const handle = (approve: boolean) => {
+    setDisabled(true);
+    onRespond(approve, item.id);
+  };
+
+  return (
+    <div className="flex flex-col">
+      <div className="flex">
+        <div className="mr-4 rounded-[16px] px-4 py-2 md:mr-24 text-black bg-white font-light">
+          <div className="mb-2 text-sm">
+            {item.server_label}: Execute tool {item.name}
+          </div>
+          <div className="flex gap-2">
+            <Button size="sm" disabled={disabled} onClick={() => handle(true)}>
+              Approve
+            </Button>
+            <Button
+              size="sm"
+              variant="destructive"
+              disabled={disabled}
+              onClick={() => handle(false)}
+            >
+              Decline
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/mcp-tools-list.tsx
+++ b/components/mcp-tools-list.tsx
@@ -1,0 +1,33 @@
+"use client";
+import React from "react";
+import { McpListToolsItem } from "@/lib/assistant";
+
+interface Props {
+  item: McpListToolsItem;
+}
+
+export default function McpToolsList({ item }: Props) {
+  return (
+    <div className="flex flex-col">
+      <div className="flex">
+        <div className="mr-4 rounded-[16px] px-4 py-2 md:mr-24 text-black bg-white font-light">
+          <div className="font-semibold mb-2">
+            {item.server_label} tools list
+          </div>
+          <div className="space-y-2 text-sm">
+            {item.tools.map((tool) => (
+              <div key={tool.name}>
+                <div className="font-medium">{tool.name}</div>
+                {tool.description && (
+                  <div className="text-zinc-500 text-xs whitespace-pre-wrap">
+                    {tool.description}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/lib/assistant.ts
+++ b/lib/assistant.ts
@@ -40,7 +40,26 @@ export interface ToolCallItem {
   files?: { file_id: string; mime_type: string }[];
 }
 
-export type Item = MessageItem | ToolCallItem;
+export interface McpListToolsItem {
+  type: "mcp_list_tools";
+  id: string;
+  server_label: string;
+  tools: { name: string; description?: string }[];
+}
+
+export interface McpApprovalRequestItem {
+  type: "mcp_approval_request";
+  id: string;
+  server_label: string;
+  name: string;
+  arguments?: string;
+}
+
+export type Item =
+  | MessageItem
+  | ToolCallItem
+  | McpListToolsItem
+  | McpApprovalRequestItem;
 
 export const handleTurn = async (
   messages: any[],
@@ -206,6 +225,27 @@ export const processMessages = async () => {
             });
             setChatMessages([...chatMessages]);
             setConversationItems([...conversationItems]);
+            break;
+          }
+          case "mcp_list_tools": {
+            chatMessages.push({
+              type: "mcp_list_tools",
+              id: item.id,
+              server_label: item.server_label,
+              tools: item.tools || [],
+            });
+            setChatMessages([...chatMessages]);
+            break;
+          }
+          case "mcp_approval_request": {
+            chatMessages.push({
+              type: "mcp_approval_request",
+              id: item.id,
+              server_label: item.server_label,
+              name: item.name,
+              arguments: item.arguments,
+            });
+            setChatMessages([...chatMessages]);
             break;
           }
           case "function_call": {


### PR DESCRIPTION
## Summary
- support showing MCP tool lists in chat
- show approval request with approve/decline buttons
- add callbacks to process approval responses

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_i_6846da584b9c832aae344a6386821e02