### PR TITLE
chore: add @radix-ui/react-slot dependency for component composition

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@radix-ui/react-dialog": "^1.1.6",
     "@radix-ui/react-dropdown-menu": "^2.1.6",
     "@radix-ui/react-popover": "^1.1.6",
+    "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-switch": "^1.1.3",
     "@radix-ui/react-tooltip": "^1.1.8",
     "@reach/visually-hidden": "^0.18.0",


### PR DESCRIPTION
Missing dependency causes build failure.